### PR TITLE
Don't remove literal '\' in interpolated strings (fixes #8)

### DIFF
--- a/syntax/dhall.vim
+++ b/syntax/dhall.vim
@@ -4,7 +4,7 @@ if exists('b:current_syntax')
     finish
 endif
 
-syntax match dhallInterpolation "\v\$\{[^\}]*\}"
+syntax match dhallInterpolation "\v\$\{[^}]*\}"
 syntax keyword dhallTodo TODO FIXME
 syntax match dhallBrackets "[<>|]"
 syntax match dhallOperator "+\|*\|#"


### PR DESCRIPTION
I'm not sure if this breaks anything related to literal `\`s?

Fixes #8 