### PR TITLE
Fixed highlighting on multiline interpolation

### DIFF
--- a/syntax/dhall.vim
+++ b/syntax/dhall.vim
@@ -4,7 +4,7 @@ if exists('b:current_syntax')
     finish
 endif
 
-syntax match dhallInterpolation "\v\$\{([^\}]|\\n)*\}"
+syntax match dhallInterpolation "\v\$\{([^\}]|\n)*\}"
 syntax keyword dhallTodo TODO FIXME
 syntax match dhallBrackets "[<>|]"
 syntax match dhallOperator "+\|*\|#"


### PR DESCRIPTION
Multiline interpolation, e.g.

```
''
${
    if True
        then "yup"
        else "nope"
}
''
```

now highlighted in the same way as single line interpolation, e.g.

```
"${someVar}"
```

Multiline previously was colored the same as the rest of the string.