### PR TITLE
Reset dhall augroup to avoid defining multiple autocmd when reloading .vimrc

### DIFF
--- a/ftplugin/dhall.vim
+++ b/ftplugin/dhall.vim
@@ -7,6 +7,8 @@ setlocal commentstring=--\ %s
 
 set smarttab
 
+autocmd! dhall
+
 if exists('g:dhall_use_ctags')
     if g:dhall_use_ctags == 1
         augroup dhall


### PR DESCRIPTION
As title, adding `autocmd! dhall` clear the autocmds in dhall augroup.