### PR TITLE
Do not put filetype detection in augroup

### DIFF
--- a/ftdetect/dhall.vim
+++ b/ftdetect/dhall.vim
@@ -1,3 +1,1 @@
-augroup dhall
-    autocmd BufNewFile,BufRead *.dhall set filetype=dhall
-augroup END
+autocmd BufNewFile,BufRead *.dhall set filetype=dhall

--- a/ftplugin/dhall.vim
+++ b/ftplugin/dhall.vim
@@ -7,13 +7,9 @@ setlocal commentstring=--\ %s
 
 set smarttab
 
-autocmd! dhall
-
 if exists('g:dhall_use_ctags')
     if g:dhall_use_ctags == 1
-        augroup dhall
-            autocmd BufWritePost *.dhall silent !ctags -R .
-        augroup END
+        autocmd BufWritePost *.dhall silent !ctags -R .
     endif
 endif
 
@@ -26,9 +22,7 @@ endfunction
 
 if exists('g:dhall_strip_whitespace')
     if g:dhall_strip_whitespace == 1
-        augroup dhall
-            au BufWritePre *.dhall silent! call StripTrailingWhitespace()
-        augroup END
+        au BufWritePre *.dhall silent! call StripTrailingWhitespace()
     endif
 endif
 
@@ -42,12 +36,8 @@ endfunction
 
 if exists('g:dhall_format')
     if g:dhall_format == 1
-        augroup dhall
-            au BufWritePost *.dhall call DhallFormat()
-        augroup END
+        au BufWritePost *.dhall call DhallFormat()
     endif
 endif
 
-augroup dhall
-    au BufNewFile,BufRead *.dhall setl shiftwidth=2
-augroup END
+au BufNewFile,BufRead *.dhall setl shiftwidth=2


### PR DESCRIPTION
Using augroup in ftdetect causes not only problems in [vim-polyglot](https://github.com/sheerun/vim-polyglot/issues/519) but also prevents `:e foo.dhall` from working (autocommands in dhall group are reset in ftplugin): https://github.com/vmchale/dhall-vim/blob/master/ftplugin/dhall.vim#L10